### PR TITLE
Add field propagation UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,8 @@
                             <div id="variantDefaultFieldsContainer"></div>
                             <button type="button" id="addVariantDefaultFieldBtn">Add Field</button>
                             <button type="button" id="applyVariantDefaultFieldsBtn">Apply to Existing Variants</button>
+                            <button type="button" id="propagateFieldsFromParentBtn">Copy Fields to Children</button>
+                            <small class="help-text">Use the "Copy" checkboxes to choose fields.</small>
                         </div>
                         <button type="button" id="generateVariantsBtn">Generate Variants</button>
                     </div>

--- a/style.css
+++ b/style.css
@@ -668,6 +668,21 @@ button[type="submit"] {
     gap: 4px;
 }
 
+.propagate-field-label {
+    margin-left: 6px;
+    font-size: 0.8em;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.help-text {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.8em;
+    color: #555;
+}
+
 #dynamicFormFields .move-field-up-btn,
 #dynamicFormFields .move-field-down-btn {
     background-color: #007bff;


### PR DESCRIPTION
## Summary
- let users pick which parent fields to copy to variants using checkboxes
- gather selected fields and propagate to chosen variant level
- style new checkboxes and help text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6880e6be11788320a3941e055b384ed4