### PR TITLE
Add UI to select variant level for field propagation

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,10 @@
                             <div id="variantDefaultFieldsContainer"></div>
                             <button type="button" id="addVariantDefaultFieldBtn">Add Field</button>
                             <button type="button" id="applyVariantDefaultFieldsBtn">Apply to Existing Variants</button>
+                            <select id="propagationLevelSelect">
+                                <option value="variant">Variant</option>
+                                <option value="subvariant">Sub-variant</option>
+                            </select>
                             <button type="button" id="propagateFieldsFromParentBtn">Copy Fields to Children</button>
                             <small class="help-text">Use the "Copy" checkboxes to choose fields.</small>
                         </div>

--- a/src/renderer/mainRenderer.js
+++ b/src/renderer/mainRenderer.js
@@ -610,6 +610,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         variantDefaultFieldsContainer: document.getElementById('variantDefaultFieldsContainer'),
         addVariantDefaultFieldBtn: document.getElementById('addVariantDefaultFieldBtn'),
         applyVariantDefaultFieldsBtn: document.getElementById('applyVariantDefaultFieldsBtn'),
+        propagationLevelSelect: document.getElementById('propagationLevelSelect'),
+        propagateFieldsFromParentBtn: document.getElementById('propagateFieldsFromParentBtn'),
         currentVariantsDisplay: document.getElementById('currentVariantsDisplay'),
 
         // Error message spans for dynamic fields are now handled by querySelector within dynamicFormFields

--- a/src/renderer/modalHandlers.js
+++ b/src/renderer/modalHandlers.js
@@ -1210,8 +1210,12 @@ function propagateFieldsFromParentPrompt() {
         alert('Select fields to copy using the checkboxes.');
         return;
     }
-    const levelStr = prompt('Copy to level 1 (variant) or 2 (subvariant)? Enter 1 or 2:');
-    const level = (levelStr && levelStr.trim() === '2') ? 'subvariant' : 'variant';
+
+    let level = 'variant';
+    if (elements.propagationLevelSelect) {
+        level = elements.propagationLevelSelect.value || 'variant';
+    }
+
     const variantsData = getVariantsFromDisplay();
     const parentValues = getParentFieldValues(fieldKeys);
     propagateFieldsToVariants(variantsData, parentValues, level);


### PR DESCRIPTION
## Summary
- add a dropdown to choose target level when copying fields to variants
- pass new elements `propagationLevelSelect` and `propagateFieldsFromParentBtn`
- read selected level instead of prompting the user

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6880ecdd6d908320a6fb459fe9adc4a0